### PR TITLE
Request Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-bot",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "homepage": "./",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-bot",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "homepage": "./",
   "dependencies": {

--- a/src/Commands.yaml
+++ b/src/Commands.yaml
@@ -20,8 +20,8 @@
 !lastgame
   - Example: !lastgame
   - Available to: Everyone
-  - What it does: Responds with a list of all previously played games from the queue.
-  - On-screen equivalent: The previously played games are shown in the History box in the bottom left.
+  - What it does: Responds with a list of the most recently played games.
+  - On-screen equivalent: Previously played games are shown in the History box in the bottom left.
   - Variants: n/a
 
 !nextgamefwd
@@ -56,6 +56,14 @@
   - Available to: Mods + broadcaster
   - What it does: Allows for game requests to be received again after using the !disablerequests command.
   - On-screen equivalent: Click the empty space on the requests screen previously occupied by the yellow subheader.
+
+!gamequeue
+  - Example: !gamequeue
+  - Available to: Everyone
+  - What it does: Lists all of the requested games currently on the wheel.
+  - On-screen equivalent: n/a
+  - Variants: !gamesqueue, !listrequests
+
 
 ###
 ### Seat Requests

--- a/src/Commands.yaml
+++ b/src/Commands.yaml
@@ -57,12 +57,12 @@
   - What it does: Allows for game requests to be received again after using the !disablerequests command.
   - On-screen equivalent: Click the empty space on the requests screen previously occupied by the yellow subheader.
 
-!gamequeue
-  - Example: !gamequeue
+!onthewheel
+  - Example: !onthewheel
   - Available to: Everyone
   - What it does: Lists all of the requested games currently on the wheel.
   - On-screen equivalent: n/a
-  - Variants: !gamesqueue, !listrequests
+  - Variants: !gamesqueued, !listrequests
 
 
 ###
@@ -149,7 +149,6 @@
   - What it does: Responds with a URL to a page displaying all requestable games, and the "short-forms" you can use to request them (e.g. "MSM" for Monster Seeking Monster).
   - On-screen equivalent: n/a
   - Variants: !gameslist
-
 !whichpack
   - Example: !whichpack TMP 2
   - Available to: Everyone

--- a/src/Commands.yaml
+++ b/src/Commands.yaml
@@ -17,6 +17,13 @@
   - On-screen equivalent: The very next game is shown in the "Up Next" box in the top left; all other upcoming games are shown in the History box in the bottom left.
   - Variants: n/a
 
+!lastgame
+  - Example: !lastgame
+  - Available to: Everyone
+  - What it does: Responds with a list of all previously played games from the queue.
+  - On-screen equivalent: The previously played games are shown in the History box in the bottom left.
+  - Variants: n/a
+
 !nextgamefwd
   - Example: !nextgamefwd
   - Available to: Mods + broadcaster
@@ -37,6 +44,18 @@
   - What it does: Allows the specified game to "jump the queue", inserting it the queue as the next game to be played ahead of any other games that won the wheel spin. (If other games were previously inserted with this command, however, those will still have priority.)
   - On-screen equivalent: n/a
   - Variants: !setnextgame
+
+!disablerequests
+  - Example: !disablerequests
+  - Available to: Mods + broadcaster
+  - What it does: Prevents game requests from being received and added to the wheel. Existing requests will remain unaffected.
+  - On-screen equivalent: Click the yellow subheader on the requests screen.
+
+!enablerequests
+  - Example: !enablerequests
+  - Available to: Mods + broadcaster
+  - What it does: Allows for game requests to be received again after using the !disablerequests command.
+  - On-screen equivalent: Click the empty space on the requests screen previously occupied by the yellow subheader.
 
 ###
 ### Seat Requests

--- a/src/MessageHandler.js
+++ b/src/MessageHandler.js
@@ -430,7 +430,7 @@ export default class MessageHandler extends Component {
         if (!gameObj) return;
 
         if (this.props.messages[gameObj.longName]) {
-            let requestedBy = (gameObj.username === tags.username) ? 'yourself, silly' : `@${gameObj.username}`;
+            let requestedBy = (this.props.messages[gameObj.longName].username === tags.username) ? 'yourself, silly' : this.props.messages[gameObj.longName].username;
             this.sendMessage(`/me @${tags.username}, ${gameObj.name} has already been requested by ${requestedBy}!`);
             return;
         }

--- a/src/MessageHandler.js
+++ b/src/MessageHandler.js
@@ -143,6 +143,38 @@ export default class MessageHandler extends Component {
             return true;
         }
 
+        //========= list requested games =========
+        if (message === "!onthewheel" || message === "!gamesqueued" || message === "!listrequests") {
+            let pipe = ' ⋆ '; // TODO: allow delimiter to be user configurable
+            let requests = Object.values(this.props.messages).map(m => m.name).sort();
+            try {
+                this.sendMessage(`/me @${username}, Requested: ${requests.join(pipe)}.`);
+            } catch(e) {
+                this.sendMessage(`/me @${username}, Sorry, there are waaaaaaaaay too many games to list and something went wrong. :p`);
+                console.log(e);
+            }
+
+            // TODO: handle if over character count
+            // TODO: determine if this is actually necessary
+            /* this.sendMessage(`/me @${username}, NOTE: There are a loooooot of games to list, but hopefully this next message won't break:`);
+            this.sendMessage(`/me @${username}, Requested: ${requests}.`);
+            requestsArr.reduce((list, str) => {
+                const last = list[list.length-1];
+                if (last && last.total + str.length <= 480) {
+                    last.total += str.length;
+                    last.words.push(str);
+                } else {
+                    list.push({
+                        total: str.length,
+                        words: [str]
+                    });
+                }
+                return list;
+            }, [])
+            .map(({ words }) => words.join(pipe));*/
+            return true;
+        }
+
         //========= enable / disable requests =========
         if ( message.startsWith("!enablerequests")) {
             if (!this.isModOrBroadcaster(username)) {
@@ -223,9 +255,9 @@ export default class MessageHandler extends Component {
         }
 
         //========= player queue management =========
-        if (message === "!caniplay" || message === "!new") {
+        if (message === "!caniplay" || message === "!new" || (message === "!dew" && this.props?.channel?.toLowerCase() === 'dewinblack')) {
             this.props?.caniplayHandler(username, {
-                sendConfirmationMsg: message !== "!new"
+                sendConfirmationMsg: message === "!caniplay"
             });
             return true;
         }
@@ -398,7 +430,8 @@ export default class MessageHandler extends Component {
         if (!gameObj) return;
 
         if (this.props.messages[gameObj.longName]) {
-            this.sendMessage(`/me @${tags.username}, ${gameObj.name} has already been requested!`);
+            let requestedBy = (gameObj.username === tags.username) ? 'yourself, silly' : `@${gameObj.username}`;
+            this.sendMessage(`/me @${tags.username}, ${gameObj.name} has already been requested by ${requestedBy}!`);
             return;
         }
 

--- a/src/__tests__/MessageHandler.test.js
+++ b/src/__tests__/MessageHandler.test.js
@@ -796,7 +796,7 @@ describe('MessageHandler', () => {
                 expect.stringContaining('no game could not be found in the list'),
             );
             expect(component.sendMessage.mock.calls[1][0]).toEqual(
-                expect.stringContaining('has already been requested!'),
+                expect.stringContaining('has already been requested'),
             );
             expect(component.sendMessage.mock.calls[2][0]).toEqual(
                 expect.stringContaining('has been replaced with'),

--- a/src/__tests__/__snapshots__/MainScreen.test.js.snap
+++ b/src/__tests__/__snapshots__/MainScreen.test.js.snap
@@ -49,8 +49,10 @@ exports[`MainScreen render should render the game request screen 1`] = `
     onMessage={[Function]}
     openQueueHandler={[Function]}
     playerExitHandler={[Function]}
+    previousGames={Array []}
     setNextGame={[Function]}
     startGame={[Function]}
+    toggleAllowGameRequests={[Function]}
     upcomingGames={Array []}
   />
   <div
@@ -204,8 +206,10 @@ exports[`MainScreen render should render the game request screen with modal 1`] 
     onMessage={[Function]}
     openQueueHandler={[Function]}
     playerExitHandler={[Function]}
+    previousGames={Array []}
     setNextGame={[Function]}
     startGame={[Function]}
+    toggleAllowGameRequests={[Function]}
     upcomingGames={Array []}
   />
   <div
@@ -388,8 +392,10 @@ exports[`MainScreen render should render the player selection screen 1`] = `
     onMessage={[Function]}
     openQueueHandler={[Function]}
     playerExitHandler={[Function]}
+    previousGames={Array []}
     setNextGame={[Function]}
     startGame={[Function]}
+    toggleAllowGameRequests={[Function]}
     upcomingGames={Array []}
   />
   <div

--- a/src/landing/MainScreen.js
+++ b/src/landing/MainScreen.js
@@ -250,10 +250,14 @@ export default class MainScreen extends Component {
         this.chatActivity.updateLastMessageTime(user);
     }
 
-    toggleAllowGameRequests = () => {
+    toggleAllowGameRequests = (allow=null) => {
+        let {allowGameRequests} = this.state;
+        if (allow !== null) {
+            allowGameRequests = !allow;
+        }
         this.setState((state) => {
             return {
-                allowGameRequests: !state.allowGameRequests
+                allowGameRequests: !allowGameRequests
             }
         })
     }
@@ -519,12 +523,14 @@ export default class MainScreen extends Component {
                     access_token={this.props.access_token}
                     onMessage={this.onMessage}
                     onDelete={this.removeGame}
+                    previousGames={this.state.history.slice(0, this.state.nextGameIdx)}
                     upcomingGames={this.state.history.slice(this.state.nextGameIdx)}
                     caniplayHandler={this.routePlayRequest}
                     playerExitHandler={this.routeLeaveRequest}
                     openQueueHandler={this.routeOpenQueueRequest}
                     closeQueueHandler={this.routeCloseQueueRequest}
                     clearQueueHandler={this.routeClearQueueRequest}
+                    toggleAllowGameRequests={this.toggleAllowGameRequests}
                     ref={this.setMessageHandlerRef}
                 />
                 <div className="left-column fade-in">


### PR DESCRIPTION
Updates in Twitch Request Wheel v0.6.3

* `!enablerequests`, `!disablerequests` - Enable / Disable Game Requests
  - To disable game requests from chat, click the yellow subheader on the Game Requests page. (aka, *Type e.g. "!request Blather Round" in chat to add*). 
  - To re-enable, click that area again. Requests will be enabled when the subheader is visible & disabled when hidden.

* `!removeuser` - Removes the specified user from the "interested" or "playing" column on the board.
  - Example: `!removeuser @username`

* `!clearopen` - Switches to the seat selection screen and removes all users from the board.

* `!lastgame` - Responds with a list of the most recently played games.

* New easter egg command :grin:
